### PR TITLE
Tiny typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Options are passed to [node-sass].
 By default the plugin will base the filename for the css on the bundle destination.
 
 ```js
-vue({
+scss({
+  //Choose *one* of these possible "output:..." options
   // Default behaviour is to write all styles to the bundle destination where .js is replaced by .css
   output: true,
 


### PR DESCRIPTION
As a side question:  in what way is this repository different than [this one](https://github.com/baza-fe/rollup-plugin-sass)?
Is it because of this `Integrates nicely with rollup-plugin-vue2`? Haven't had the change to play with vue2 yet, not even vue.v1!