### PR TITLE
Modify output option to generate missing parent folders in path

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -71,8 +71,8 @@ export default function css(options = {}) {
         dest = dest + '.css'
       }
 
-      // Ensure the parent folders of dest exist (create the missing ones)
-      ensureParentDirsSync(dirname(dest));
+      // Ensure that dest parent folders exist (create the missing ones)
+      ensureParentDirsSync(dirname(dest))
 
       // Emit styles to file
       writeFile(dest, css, (err) => {
@@ -99,15 +99,15 @@ function getSize (bytes) {
 
 function ensureParentDirsSync (dir) {
   if (existsSync(dir)) {
-    return;
+    return
   }
 
   try {
-    mkdirSync(dir);
+    mkdirSync(dir)
   } catch (err) {
     if (err.code === 'ENOENT') {
-      ensureParentDirsSync(dirname(dir));
-      ensureParentDirsSync(dir);
+      ensureParentDirsSync(dirname(dir))
+      ensureParentDirsSync(dir)
     }
   }
 }

--- a/index.es.js
+++ b/index.es.js
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs'
+import { existsSync, mkdirSync, writeFile } from 'fs'
 import { dirname } from 'path'
 import { createFilter } from 'rollup-pluginutils'
 import { renderSync } from 'node-sass'
@@ -71,6 +71,9 @@ export default function css(options = {}) {
         dest = dest + '.css'
       }
 
+      // Ensure the parent folders of dest exist (create the missing ones)
+      ensureParentDirsSync(dirname(dest));
+
       // Emit styles to file
       writeFile(dest, css, (err) => {
         if (err) {
@@ -92,4 +95,19 @@ function getSize (bytes) {
     : bytes < 1024000
     ? (bytes / 1024).toPrecision(3) + ' kB'
     : (bytes / 1024 / 1024).toPrecision(4) + ' MB'
+}
+
+function ensureParentDirsSync (dir) {
+  if (existsSync(dir)) {
+    return;
+  }
+
+  try {
+    mkdirSync(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      ensureParentDirsSync(dirname(dir));
+      ensureParentDirsSync(dir);
+    }
+  }
 }


### PR DESCRIPTION
`output` option only accept an existent path to save the CSS
bundle. With this edit, we can specify a partial existent path.
The missing folders will be created when needed.

So, now I can:

```js
scss({
      outputStyle: 'compressed',
      output: 'build/styles/bundle.css',
    }),
```

in `rollup.config.js` and it will generate the bundle in the specified folder, inside my project. Even if `styles` folder or even `build` folder doesn't still exist. Without this change, we can only put the file in an existing folder, so we need to create it... manually. That's far from ideal, I think.

**Edit**: I created another commit for deleting the semicolons. I prefer the semicolons, so I didn't realize previously you wasn't using them.