### PR TITLE
Adding an option to ignore an error from node-sass for empty css sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ scss({
   },
 
   // Disable any style output or callbacks, import as string
-  output: false
+  output: false,
+
+  // Should ignore empty css source, without this option node-sass will throw an error of:
+  // "No input specified: provide a file name or a source string to process"
+  // default is false
+  ignoreEmpty: true
 })
 ```
 

--- a/index.es.js
+++ b/index.es.js
@@ -43,6 +43,12 @@ export default function css(options = {}) {
       for (const id in styles) {
         css += styles[id] || ''
       }
+      
+      // node-sass will throw an error with "No input specified: provide a file name or a source string to process"
+      // if the css source is empty
+      if (options.ignoreEmpty && !css) {
+        return Promise.resolve();
+      }
 
       // Compile SASS to CSS
       includePaths = includePaths.filter((v, i, a) => a.indexOf(v) === i)


### PR DESCRIPTION
When trying to compile bundles without any css source
node-sass throws the following error and it stops the rollup build:
**"No input specified: provide a file name or a source string to process"**

To prevent that error when not needed, I added an option called **ignoreEmpty**
which will skip the node-sass process when it is true and the css source it empty.