### PR TITLE
Update node-sass dependency to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "index.es.js"
   ],
   "dependencies": {
-    "node-sass": "^3.10.1",
+    "node-sass": "^4.5.3",
     "rollup-pluginutils": "^1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I've updated the node-sass dependency to `^4.5.3` because the currently referenced `^3.10.1` is leading to `v3.10.1` by semver.

But this version is currently missing some binaries for windows 64bit platforms and does not build. https://github.com/sass/node-sass/releases/tag/v3.13.1

Thanks in advance.
Tim