### PR TITLE
Add an option to propagate node-sass error up to node process

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <a href="https://github.com/thgh/rollup-plugin-scss/releases">
   <img src="https://img.shields.io/github/release/thgh/rollup-plugin-scss.svg" alt="Latest Version" />
 </a>
-  
+
 ## Installation
 ```
 npm install --save-dev rollup-plugin-scss
@@ -64,7 +64,10 @@ scss({
   },
 
   // Disable any style output or callbacks, import as string
-  output: false
+  output: false,
+
+  // Determine if node process should be terminated on error (default: false)
+  failOnError: true,
 })
 ```
 

--- a/index.es.js
+++ b/index.es.js
@@ -52,6 +52,9 @@ export default function css(options = {}) {
             includePaths
           }, options)).css.toString();
         } catch (e) {
+          if (options.failOnError) {
+            throw e;
+          }
           console.log();
           console.log(red('Error:\n\t' + e.message));
           if (e.message.includes('Invalid CSS')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-scss",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rollup multiple .scss, .sass and .css imports",
   "main": "index.cjs.js",
   "module": "index.es.js",


### PR DESCRIPTION
I use `nvm` and sometimes after changing NodeJS version, I am required to rebuild `node-sass` package in order to have it meeting current NodeJS version bindings.

I would like to be able to set build process the way, if there is any error coming from `node-sass` library, the build process is terminated (it's really handy while using this package in deployment pipeline).