### PR TITLE
Fixing size output conditional

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -112,7 +112,7 @@ export default function css (options = {}) {
           if (opts.verbose !== false) {
             if (err) {
               console.error(red(err))
-            } else {
+            } else if (css) {
               console.log(green(dest), getSize(css.length))
             }
           }


### PR DESCRIPTION
This change prevents the plugin from trying to output size information if css is falsy. In my case, if I have an undefined variable, I get the intended error message, but I also get this other error message that is not relevant:

```
Error:
	Undefined variable: "$input-box-shadow".

/Users/iwalter/binxhealth/jupiter/node_modules/rollup-plugin-scss/index.cjs.js:120
              console.log(green(dest), getSize(css.length));
                                                   ^

TypeError: Cannot read property 'length' of undefined
    at /Users/iwalter/binxhealth/jupiter/node_modules/rollup-plugin-scss/index.cjs.js:120:52
    at /Users/iwalter/binxhealth/jupiter/node_modules/graceful-fs/graceful-fs.js:45:10
    at FSReqCallback.args [as oncomplete] (fs.js:145:20)
error Command failed with exit code 1.
```