### PR TITLE
fix name guessing in generateBundle

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -97,7 +97,7 @@ export default function css (options = {}) {
           }
 
           // Guess destination filename
-          dest = opts.dest || opts.file || 'bundle.js'
+          dest = dest || opts.file || 'bundle.js'
           if (dest.endsWith('.js')) {
             dest = dest.slice(0, -3)
           }


### PR DESCRIPTION
`opts` does not contain the `dest` property. So we could either use `options.dest` or just `dest` since it is in the scope anyways.