### PR TITLE
Adds fix to add include path before processing when output is false

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -55,6 +55,9 @@ export default function css (options = {}) {
         return
       }
 
+      // Add the include path before doing any processing
+      includePaths.push(dirname(id))
+
       // Rebuild all scss files if anything happens to this folder
       // TODO: check if it's possible to get a list of all dependent scss files
       //       and only watch those
@@ -74,7 +77,6 @@ export default function css (options = {}) {
 
       // Map of every stylesheet
       styles[id] = code
-      includePaths.push(dirname(id))
 
       return ''
     },


### PR DESCRIPTION
I had a problem with relative paths when trying to add scss files as modules when they contain @import with relative paths.

Noticed that `includePaths.push(dirname(id))` was done after processing and returning the result and the include path for the file was not added to node-sass before processing the file.

So i moved the line up a bit and added a comment which seemed to work ok