### PR TITLE
Resolve processor as a promise during transform step

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ scss({
   // Use a node-sass compatible compiler (default: node-sass)
   sass: require('sass'),
 
+  // Process resulting CSS, e.g. postcss + autoprefixer
+  processor: css => {
+    return Promise.resolve(postcss([autoprefixer]).process(css))
+      .then(result => result.css)
+  }
+
   // Add file/folder to be monitored in watch mode so that changes to these files will trigger rebuilds.
   // Do not choose a directory where rollup output or dest is pointed to as this will cause an infinite loop
   watch: 'src/styles/components',

--- a/index.es.js
+++ b/index.es.js
@@ -68,11 +68,10 @@ export default function css (options = {}) {
 
       // When output is disabled, the stylesheet is exported as a string
       if (options.output === false) {
-        const css = compileToCSS(code)
-        return {
+        return Promise.resolve(compileToCSS(code)).then(css => ({
           code: 'export default ' + JSON.stringify(css),
           map: { mappings: '' }
-        }
+        }))
       }
 
       // Map of every stylesheet
@@ -94,7 +93,7 @@ export default function css (options = {}) {
 
       const css = compileToCSS(scss)
 
-      // Resolve if porcessor returned a Promise
+      // Resolve if processor returned a Promise
       Promise.resolve(css).then(css => {
         // Emit styles through callback
         if (typeof options.output === 'function') {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "fix": "standard --fix rollup.config.js index.es.js",
     "test:node-sass": "cd test/node-sass && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp output.css expected.css && cd ../..",
     "test:sass": "cd test/sass && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp output.css expected.css && cd ../..",
-    "test": "npm run test:node-sass && npm run test:sass",
+    "test:processor": "cd test/processor && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp output.css expected.css && cd ../..",
+    "test": "npm run test:node-sass && npm run test:sass && npm run test:processor",
     "testw": "cd test/node-sass && rm -f output.* && rollup -cw; cd ..",
     "prepare": "rollup -c"
   },
@@ -41,6 +42,8 @@
     "rollup-pluginutils": "2"
   },
   "devDependencies": {
+    "autoprefixer": "^9.8.6",
+    "postcss": "^7.0.32",
     "rollup": "2",
     "rollup-plugin-buble": "0",
     "sass": "^1.26.3",

--- a/test/input.scss
+++ b/test/input.scss
@@ -1,7 +1,8 @@
 .rollup {
   .plugin {
     .scss {
-      color: green
+      color: green;
+      user-select: none;
     }
   }
 }

--- a/test/node-sass/expected.css
+++ b/test/node-sass/expected.css
@@ -1,2 +1,3 @@
 .rollup .plugin .scss {
-  color: green; }
+  color: green;
+  user-select: none; }

--- a/test/processor/expected.css
+++ b/test/processor/expected.css
@@ -1,0 +1,4 @@
+.rollup .plugin .scss {
+  color: green;
+  -ms-user-select: none;
+      user-select: none; }

--- a/test/processor/rollup.config.js
+++ b/test/processor/rollup.config.js
@@ -1,0 +1,23 @@
+import scss from '../../index.es.js'
+import postcss from "postcss"
+import autoprefixer from "autoprefixer"
+
+export default {
+  input: '../input.js',
+  output: {
+    file: 'output.js',
+    format: 'esm'
+  },
+  plugins: [
+    scss({
+      processor: css => {
+        return Promise
+          .resolve(
+            postcss([autoprefixer({ overrideBrowserslist: "Edge 18" })])
+              .process(css, { from: undefined })
+          )
+          .then(result => result.css)
+      }
+    })
+  ]
+}

--- a/test/sass/expected.css
+++ b/test/sass/expected.css
@@ -1,3 +1,4 @@
 .rollup .plugin .scss {
   color: green;
+  user-select: none;
 }


### PR DESCRIPTION
Currently, this plugin will return `{}` when attempting to inline the output CSS with an async `options.processor`.

Fix: Resolve `options.processor` as a promise.

Checklist:
- [x] Fixes #49
- [x] Add test case + tests are passing
- [x] Add example to readme