### PR TITLE
Remove node-sass from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `rollup-plugin-scss` will be documented in this file.
 
 ## [Unreleased]
+- Remove `node-sass` from optionalDependencies @astappiev <br/>
+  **You have to specify `node-sass` or `sass` in your project dependencies alongside `rollup-plugin-scss`**
 
 ## [2.6.1] - 2020-10-01
 ### Updated

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ npm install --save-dev rollup-plugin-scss
 npm install --save-dev rollup-plugin-scss@0
 ```
 
+Since v3, you have to install Sass compiler manually:
+```
+# Node Sass (deprecated)
+npm install --save-dev node-sass
+
+# Dart Sass
+npm install --save-dev sass
+```
+If any of them is installed, it will be used automatically, if both installed `node-sass` will be used.
+
 ## Usage
 ```js
 // rollup.config.js
@@ -84,7 +94,9 @@ scss({
   // Prefix global scss. Useful for variables and mixins.
   prefix: `@import "./fonts.scss";`,
 
-  // Use a node-sass compatible compiler (default: node-sass)
+  // A Sass (node-sass compatible) compiler to use
+  // - node-sass and sass packages are picked up automatically
+  // - you can use this option to specify custom package (e.g. a fork of one of them)
   sass: require('sass'),
 
   // Run postcss processor before output

--- a/index.es.js
+++ b/index.es.js
@@ -11,12 +11,20 @@ export default function css (options = {}) {
   let includePaths = options.includePaths || ['node_modules/']
   includePaths.push(process.cwd())
 
+  const loadSassLibrary = function () {
+    try {
+      return require('node-sass')
+    } catch (ignored) {
+      return require('sass')
+    }
+  }
+
   const compileToCSS = function (scss) {
     // Compile SASS to CSS
     if (scss.length) {
       includePaths = includePaths.filter((v, i, a) => a.indexOf(v) === i)
       try {
-        const sass = options.sass || require('node-sass')
+        const sass = options.sass || loadSassLibrary()
         const css = sass.renderSync(Object.assign({
           data: prefix + scss,
           includePaths
@@ -45,8 +53,8 @@ export default function css (options = {}) {
           console.log('Line:   ' + e.line)
           console.log('Column: ' + e.column)
         }
-        if (e.message.includes('node-sass') && e.message.includes('find module')) {
-          console.log(green('Solution:\n\t' + 'npm install --save node-sass'))
+        if (e.message.includes('sass') && e.message.includes('find module')) {
+          console.log(green('Solution:\n\t' + 'npm install --save-dev sass' + '\n\tor\n\t' + 'npm install --save-dev node-sass'))
         }
         if (e.message.includes('node-sass') && e.message.includes('bindings')) {
           console.log(green('Solution:\n\t' + 'npm rebuild node-sass --force'))

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
   "dependencies": {
     "rollup-pluginutils": "2"
   },
+  "peerDependencies": {
+    "sass": ">=1.0.0",
+    "node-sass": ">=4.0.0"
+  },
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "postcss": "^7.0.32",
@@ -48,8 +52,5 @@
     "rollup-plugin-buble": "0",
     "sass": "^1.26.3",
     "standard": "14"
-  },
-  "optionalDependencies": {
-    "node-sass": "4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
   "dependencies": {
     "rollup-pluginutils": "2"
   },
-  "peerDependencies": {
-    "sass": ">=1.0.0",
-    "node-sass": ">=4.0.0"
-  },
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "postcss": "^7.0.32",


### PR DESCRIPTION
As described in #61, even after moving `node-sass` to optional dependencies it is still downloaded by npm/yarn.

Moving it to peer dependencies solves the issue.
Now users have to specify what package they want to use `sass` or `node-sass` in their projects.