### PR TITLE
Update README with an "includePaths" opt. example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ scss({
   // Disable any style output or callbacks, import as string
   output: false,
   
+  // An array of paths to resolve @import from (default: ["node_modules"]);
+  // in the context of a monorepo you might want to include more paths.
+  includePaths: ["node_modules", "../../node_modules"],
+  
   // Choose files to include in processing (default: ['/**/*.css', '/**/*.scss', '/**/*.sass'])
   include: [],
   


### PR DESCRIPTION
Monorepo tools pull dependencies to the root node_modules folder. Libsass or Dart-sass do not use something like `require.resolve` and need explicit paths to "node_modules" folder.