### PR TITLE
Added Yarn PnP support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFile } from 'fs'
-import { dirname, resolve } from 'path'
+import { basename, dirname, resolve } from 'path'
 import { createFilter, CreateFilter } from 'rollup-pluginutils'
 
 import type { Plugin } from 'rollup'
@@ -86,23 +86,13 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
                 prev: string,
                 done: ImporterDoneCallback
               ): ImporterReturnType | void => {
-                let resolved
-                const localPath = resolve(prefix + scss, url)
-
-                if (existsSync(localPath)) {
-                  resolved = localPath
-                } else if (existsSync(url)) {
-                  resolved = url
-                } else {
-                  const cleanUrl = url.startsWith('~')
-                    ? url.replace('~', '')
-                    : url
-                  resolved = require.resolve(cleanUrl, {
-                    paths: [prefix + scss]
-                  })
-                }
-
-                return done({ file: resolved })
+                const cleanUrl = url.startsWith('~')
+                  ? url.replace('~', '')
+                  : url
+                const resolved = require.resolve(cleanUrl, {
+                  paths: [prefix + scss]
+                })
+                return resolved ? done({ file: resolved }) : null
               }
             },
             options

--- a/index.ts
+++ b/index.ts
@@ -86,17 +86,13 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
                 prev: string,
                 done: ImporterDoneCallback
               ): ImporterReturnType | void => {
-                if (url.startsWith('.')) {
-                  return null
-                }
-
                 const cleanUrl = url.startsWith('~')
                   ? url.replace('~', '')
                   : url
                 const resolved = require.resolve(cleanUrl, {
                   paths: [prefix + scss]
                 })
-                return existsSync(resolved) ? done({ file: resolved }) : null
+                return resolved ? { file: resolved } : null
               }
             },
             options

--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,8 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
 
                 if (existsSync(url)) {
                   resolved = url
+                } else if (existsSync(prev)) {
+                  resolved = prev
                 } else {
                   const finalUrl = url.startsWith('~')
                     ? url.replace('~', '')

--- a/index.ts
+++ b/index.ts
@@ -86,6 +86,10 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
                 prev: string,
                 done: ImporterDoneCallback
               ): ImporterReturnType | void => {
+                if (url.startsWith('.')) {
+                  return null
+                }
+
                 const cleanUrl = url.startsWith('~')
                   ? url.replace('~', '')
                   : url

--- a/index.ts
+++ b/index.ts
@@ -76,7 +76,32 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
             {
               data: prefix + scss,
               outFile: dest,
-              includePaths
+              includePaths,
+              importer: (
+                url: string,
+                prev: string,
+                done: (
+                  data: { file: string } | { contents: string } | Error | null
+                ) => void
+              ):
+                | { file: string }
+                | { contents: string }
+                | Error
+                | null
+                | void => {
+                let resolved
+
+                if (existsSync(url)) {
+                  resolved = url
+                } else {
+                  const finalUrl = url.startsWith('~')
+                    ? url.replace('~', '')
+                    : url
+                  resolved = require.resolve(finalUrl)
+                }
+
+                return { file: resolved }
+              }
             },
             options
           )

--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,7 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
                 const resolved = require.resolve(cleanUrl, {
                   paths: [prefix + scss]
                 })
-                return resolved ? done({ file: resolved }) : null
+                return existsSync(resolved) ? done({ file: resolved }) : null
               }
             },
             options

--- a/index.ts
+++ b/index.ts
@@ -86,6 +86,8 @@ export default function scss(options: CSSPluginOptions = {}): Plugin {
                 prev: string,
                 done: ImporterDoneCallback
               ): ImporterReturnType | void => {
+                if (url.startsWith('.')) return null
+
                 const cleanUrl = url.startsWith('~')
                   ? url.replace('~', '')
                   : url


### PR DESCRIPTION
In connection with issue #60, this pull request adds Yarn PnP support by allowing Yarn to provide any of the necessary files from NPM. All local files are still simply passed directly to the sass compiler of the user's choice.