### PR TITLE
fix: add `outputStyle` key to CSSPluginOptions interface

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ export interface CSSPluginOptions {
   sourceMap?: boolean
   verbose?: boolean
   watch?: string | string[]
+  outputStyle?: string
 }
 
 type ImporterReturnType = { file: string } | { contents: string } | Error | null


### PR DESCRIPTION
- [x] Fixes issue: 
![Screenshot 2021-08-19 at 3 30 10 PM](https://user-images.githubusercontent.com/19776877/130049711-418e5322-4592-405e-80e2-fb7b1a67bbe1.png)


Basically, if you enable typescript for rollup.config files, as per the [example](https://github.com/thgh/rollup-plugin-scss#examples), the `CSSPluginOptions` interface doesn't have the `outputStyle` key present. 

This PR fixes that.