### PR TITLE
Handle node module duplicate filename import resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:postcss": "cd test/postcss && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp output.css expected.css && cd ../..",
     "test:processor": "cd test/processor && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp output.css expected.css && cd ../..",
     "test:sourcemap": "cd test/sourcemap && rm -f output.* && rollup -c && cmp output.js ../expected.js && cmp nested/output.css expected.css && cmp nested/output.css.map expected.css.map && cd ../..",
-    "test": "npm run test:node-sass && npm run test:sass && npm run test:processor && npm run test:postcss && npm run test:sourcemap && npm run test:insert",
+    "test:import-resolution": "cd test/import-resolution && node setup.js && rm -f output.* && rollup -c && node teardown.js && cmp output.js expected.js && cmp output.css expected.css && cd ../..",
+    "test": "npm run test:node-sass && npm run test:sass && npm run test:processor && npm run test:postcss && npm run test:sourcemap && npm run test:insert && npm run test:import-resolution",
     "testw": "cd test/node-sass && rm -f output.* && rollup -cw; cd ..",
     "prepare": "rollup -c"
   },

--- a/test/import-resolution/expected.css
+++ b/test/import-resolution/expected.css
@@ -1,0 +1,8 @@
+.importable {
+  color: red;
+}
+
+.rollup .plugin .scss {
+  color: green;
+  user-select: none;
+}

--- a/test/import-resolution/expected.js
+++ b/test/import-resolution/expected.js
@@ -1,0 +1,1 @@
+console.log('scss imported from native files and node_modules');

--- a/test/import-resolution/input.js
+++ b/test/import-resolution/input.js
@@ -1,0 +1,3 @@
+import './input.scss'
+
+console.log('scss imported from native files and node_modules')

--- a/test/import-resolution/input.scss
+++ b/test/import-resolution/input.scss
@@ -1,0 +1,10 @@
+@import 'import-resolution-test/main';
+
+.rollup {
+  .plugin {
+    .scss {
+      color: green;
+      user-select: none;
+    }
+  }
+}

--- a/test/import-resolution/main.js
+++ b/test/import-resolution/main.js
@@ -1,0 +1,1 @@
+// A .js file with the same name as the intended .scss file to be imported.

--- a/test/import-resolution/main.scss
+++ b/test/import-resolution/main.scss
@@ -1,0 +1,3 @@
+.importable {
+  color: red;
+}

--- a/test/import-resolution/rollup.config.js
+++ b/test/import-resolution/rollup.config.js
@@ -1,0 +1,10 @@
+import scss from '../../index.es.js'
+
+export default {
+  input: './input.js',
+  output: {
+    file: 'output.js',
+    format: 'esm'
+  },
+  plugins: [scss({ fileName: 'output.css' })]
+}

--- a/test/import-resolution/setup.js
+++ b/test/import-resolution/setup.js
@@ -1,0 +1,39 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const NODE_MODULES_MOCK_PACKAGE_PATH = path.join(__dirname, '../../node_modules/import-resolution-test');
+const CURRENT_DIRECTORY_PATH = path.join(__dirname, '.');
+
+const IMPORTABLE_FILE_NAME = 'main';
+const IMPORTABLE_JS_FILE_NAME = `${IMPORTABLE_FILE_NAME}.js`;
+const IMPORTABLE_SCSS_FILE_NAME = `${IMPORTABLE_FILE_NAME}.scss`;
+
+/* If one does not already exist,
+ * create a path to the node_modules mock package. */
+if (!fs.existsSync(NODE_MODULES_MOCK_PACKAGE_PATH)) {
+  fs.mkdirSync(NODE_MODULES_MOCK_PACKAGE_PATH);
+}
+
+/* Copy the specified file with the .js extension
+ * to the node_modules mock package. */
+fs.copyFile(
+  `${CURRENT_DIRECTORY_PATH}/${IMPORTABLE_JS_FILE_NAME}`,
+  `${NODE_MODULES_MOCK_PACKAGE_PATH}/${IMPORTABLE_JS_FILE_NAME}`,
+  error => {
+    if (error) {
+      console.log(error);
+    }
+  }
+)
+
+/* Copy the specified file with the .scss extension
+ * to the node_modules mock package. */
+fs.copyFile(
+  `${CURRENT_DIRECTORY_PATH}/${IMPORTABLE_SCSS_FILE_NAME}`,
+  `${NODE_MODULES_MOCK_PACKAGE_PATH}/${IMPORTABLE_SCSS_FILE_NAME}`,
+  error => {
+    if (error) {
+      console.log(error);
+    }
+  }
+)

--- a/test/import-resolution/teardown.js
+++ b/test/import-resolution/teardown.js
@@ -1,0 +1,16 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const NODE_MODULES_MOCK_PACKAGE_PATH = path.join(__dirname, '../../node_modules/import-resolution-test');
+
+/* Now that it has served its purpose,
+ * remove the node_modules mock package. */
+fs.rm(
+  NODE_MODULES_MOCK_PACKAGE_PATH,
+  { recursive: true, force: true },
+  error => {
+    if (error) {
+      throw error;
+    }
+  }
+);


### PR DESCRIPTION
## Description
This PR addresses an issue that arises from the following conditions:

### App directory structure
```
├── node_modules
│     ├── package-name
│           ├── main.js
│           ├── main.scss
├── src
│     ├── client
│           ├── stylesheets
│                   ├── index.scss
└── rollup.config.js
```

### rollup.config.js
```js
import scss from 'rollup-plugin-scss';
import * as sass from 'sass';

export default {
	input: 'src/client/stylesheets/index.scss',
	output: {
		dir: 'public'
	},
	plugins: [
		scss({
			fileName: 'main.css',
			failOnError: true,
			sass
		})
	]
};
```

### index.scss
```scss
…
@import 'package-name/main';
…
```

Running `rollup --config` results in:

```
[!] (plugin scss) Error: Can't find stylesheet to import.
   ╷
17 │ @import 'package-name/main';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  stdin 17:9  root stylesheet
```

The values at the below lines are:
- `cleanUrl`: `package-name/main`
- `resolved`: `/{path}/app-name/node_modules/package-name/main.js`.

https://github.com/thgh/rollup-plugin-scss/blob/dd41d2d7a4ce924a0f57e7e59cf9c7b0edd9e146/index.ts#L138-L140

`require.resolve()` seemingly prioritises files with a `.js` extension over files with a `.scss` extension that this plugin will be interested in. It is not treating file extensions alphabetically: the same thing happens if `main.css` is added alongside `main.js` and `main.scss`.

The changes applied by this PR enable the process to make subsequent `require.resolve()` calls to try and resolve a file with a `.css`, `.scss`, or `.sass` file extension.

## Actual use case
I am migrating an app ([dramatis-ssr](https://github.com/andygout/dramatis-ssr)) to native ECMAScript modules and in the process am switching from Webpack to Rollup — [branch](https://github.com/andygout/dramatis-ssr/tree/use-nodejs-native-ecmascript-modules).

The app uses a package called [o-autocomplete](https://www.npmjs.com/package/@financial-times/o-autocomplete) ([GitHub repo](https://github.com/Financial-Times/origami/tree/main/components/o-autocomplete)) from a monorepo called [origami](https://github.com/Financial-Times/origami).

o-atuocomplete includes a `main.js` and `main.scss` file.

## Considerations
### Could `require.resolve()` take an argument that specifies a file extension?
This would mean that the first call to `require.resolve()` could specify that it is only looking for files with a `.css`, `.scss`, or `.sass`, and consequently avoid the risk of resolving with a duplicate-named file with a `.js` extension, thereby preventing the need for subsequent additional `require.resolve()` calls.

This feature was requested in nodejs/node GitHub issue: [add `ext` option in `require.resolve`](https://github.com/nodejs/node/issues/41067).

In that issue, reference is made to [`require.extensions`](https://nodejs.org/api/modules.html#requireextensions), which was added in Node.js v0.3.0 and deprecated since v0.10.6, and whose documentation states:

> Avoid using `require.extensions`. Use could cause subtle bugs and resolving the extensions gets slower with each registered extension.

Admittedly, the changes proposed in this PR result in multiple to attempts to resolve the same import, but only in the scenario of there being a duplicate-named file with a `.js` extension, which feels more anomalous than common.

The issue also referenced the [resolve](https://www.npmjs.com/package/resolve) package but I was wary that it may include different behaviour to `require.resolve()`. I attempted a direct switch and it seems that the `paths` option requires different values, indicating that more substantial changes would be required, which it felt best to avoid.

### Could the `allowedExtensions` value be derived from the `options.include` value (or its default)?

If the `options.include` value(s) were exclusively globs (as the default value is — `['/**/*.css', '/**/*.scss', '/**/*.sass']`) then yes, as the file extensions could be extracted from those strings via `String.prototype.match()`.

In fact, a feature was added to Node.js v22.5.0: [`path.matchesGlob()`](https://nodejs.org/api/path.html#pathmatchesglobpath-pattern), which determines if `path` matches the `pattern`:

```js
// path.matchesGlob(path, pattern);

path.matchesGlob('/foo/bar', '/foo/*'); // true
path.matchesGlob('/foo/bar*', 'foo/bird'); // false 
```

This would enable the globs to be used directly in deciding the value to be assigned to the `resolvedHasAllowedExtension` variable.

However, the (TypeScript) types indicate that the `options.include` value(s) can be not only globs but also regular expressions, which cannot be used to append a file extension to the `cleanUrl` value that is used as the `require.resolve()` `request` argument, which is the approach that has been implemented in this PR:

```js
resolved = require.resolve(cleanUrl + allowedExtension, {
	paths: [prefix + scss]
})
```

## Tests
This PR adds tests which simulate the conditions via a setup and teardown task which creates then deletes a mock package directory in the `node_modules` purely for the amount of time required for the Rollup task to run its build task (to create the compiled files upon which to perform comparisons).

I have called this mock package `import-resolution-test`, which feels like it should safely avoid clashing with the names of any actual node modules that are present (or are ever likely to become present) in the `node_modules` directory.

I am not sure if there is a convention for naming such mock packages to avoid any naming clashes (e.g. a leading underscore: `_import-resolution-test`?).

## Release version
[Semver versioning](https://semver.org) recommends that, if approved, these changes, which are essentially a bug fix, should be a patch release:

> PATCH version when you make backward compatible bug fixes